### PR TITLE
FIX: Windows Memory Size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 # set minimum cmake version
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
+# Uncomment for VERBOSE Makefiles. Useful for debugging.
+#set(CMAKE_VERBOSE_MAKEFILE ON)
+
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 # project name and language

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ list(APPEND _sources
     output.f
 )
 
+if (WIN32)
+    add_definitions(-DWIN)
+endif()
+
 if(USE_MPI)
     find_package(MPI REQUIRED)
     add_definitions(${MPI_Fortran_COMPILE_FLAGS} -DUSE_MPI)
@@ -51,6 +55,8 @@ else()
     list(APPEND _sources mpi_single.f)
     add_executable(genesis2 ${_sources})
 endif()
+
+target_compile_options(genesis2 PRIVATE -cpp)
 
 install(TARGETS genesis2
         RUNTIME DESTINATION bin)

--- a/check.f
+++ b/check.f
@@ -5,7 +5,7 @@ c     such as magin and maginfile. guerantee compability for
 c     older versions of genesis 1.3
 c     ------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'sim.cmn'
       include 'mpi.cmn'
@@ -199,7 +199,7 @@ c     ==================================================================
 c     checks some boundaries of the input file.
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'time.cmn'
       include  'io.cmn'

--- a/diagno.f
+++ b/diagno.f
@@ -7,7 +7,7 @@ c     all calculation are stored in a history arrays which will be
 c     written to a file ad the end of the run.
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'sim.cmn'
       include  'input.cmn'
       include  'field.cmn'

--- a/esource.f
+++ b/esource.f
@@ -5,7 +5,7 @@ c     all particle are discretized on a radial mesh for all
 c     selected azimutal and longitudinal fourier modes.
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'particle.cmn'
       include  'work.cmn'

--- a/field.f
+++ b/field.f
@@ -8,7 +8,7 @@ c        to use tridiag methode transpose data array:
 c        (1)->u(n)->u(i,j)->u(j,i)->u(n)->(2)->transpose again 
 c     ------------------------------------------------------------------
 c
-      include   'genesis.def'
+#include "genesis.def"
       include   'field.cmn'
       include   'input.cmn'
 c
@@ -108,7 +108,7 @@ c     solve a tridiagonal system for cartesian mesh in x direction
 c     cbet and cwet are precalculated in auxval
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'field.cmn'
 
@@ -142,7 +142,7 @@ c     solve a tridiagonal system for cartesian mesh in y direction
 c     cbet and cwet are precalculated in auxval
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
 
@@ -181,7 +181,7 @@ c     construct the diagonal matrix for field equation
 c     do some precalculation for field solver
 c     ----------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'field.cmn'
       include 'work.cmn'

--- a/genesis.def
+++ b/genesis.def
@@ -8,8 +8,12 @@ c
       integer original,f_sdds,keepdist
 c
       parameter(
-     +          genver = 1.0,                !genesis version
+     +          genver = 2.2,                !genesis version
+#if WIN == 1
+     +			platf  ='Win ',              !platform
+#else
      +			platf  ='Unix',              !platform
+#endif
      +          original = 1 ,               !indicator for original filetype
      +          f_sdds = 2 ,                 !indicator for sdds filetype
      +          npmax  = 1000001,             !# of particles

--- a/genesis.def
+++ b/genesis.def
@@ -14,7 +14,7 @@ c
      +          f_sdds = 2 ,                 !indicator for sdds filetype
      +          npmax  = 1000001,             !# of particles
      +          nzmax  = 10000,              !# of integration steps
-#if defined(WIN)
+#if WIN == 1
      +          nsmax  = 50000,              !# of slices
      +          nhmax  = 7,                  !maximum of harmonics
 #else
@@ -32,7 +32,7 @@ c
      +          tiny   = 1.d-25,             !check i for precission 
      +          small  = 1.d-7,              !check ii for precission
      +          nrgrid = 1000,               !number of radial points for s. c.
-#if defined(WIN)
+#if WIN == 1
      +          ncmax  = 261)                !# of gridpoints of cartesian mesh
 #else
      +          ncmax  = 503)                !# of gridpoints of cartesian mesh

--- a/genesis.def
+++ b/genesis.def
@@ -14,8 +14,13 @@ c
      +          f_sdds = 2 ,                 !indicator for sdds filetype
      +          npmax  = 1000001,             !# of particles
      +          nzmax  = 10000,              !# of integration steps
+#if defined(WIN)
+     +          nsmax  = 50000,              !# of slices
+     +          nhmax  = 7,                  !maximum of harmonics
+#else
      +          nsmax  = 150000,              !# of slices
      +          nhmax  = 5,                  !maximum of harmonics
+#endif
      +          ndmax  = 1250000,            !maximum of particle in imported distribution
      +          keepdist = 1,                !<> 0 keeps distribution in memory
      +          eev    = 510999.06d0,        !energy units (mc^2) in ev
@@ -27,7 +32,11 @@ c
      +          tiny   = 1.d-25,             !check i for precission 
      +          small  = 1.d-7,              !check ii for precission
      +          nrgrid = 1000,               !number of radial points for s. c.
+#if defined(WIN)
+     +          ncmax  = 261)                !# of gridpoints of cartesian mesh
+#else
      +          ncmax  = 503)                !# of gridpoints of cartesian mesh
+#endif
 c
 c     error codes 
 c

--- a/incoherent.f
+++ b/incoherent.f
@@ -9,7 +9,7 @@ c     with respect to e. saldin nima381 (1996) p 545-547
 c     ------------------------------------------------------------------
 c
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'particle.cmn'
 c

--- a/initrun.f
+++ b/initrun.f
@@ -6,7 +6,7 @@ c     claculating/normalizing some auxiliary variables
 c
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'sim.cmn'

--- a/input.f
+++ b/input.f
@@ -3,7 +3,7 @@ c     ==================================================================
 c     manages all initial input for genesis
 c     ------------------------------------------------------------------
 
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'io.cmn'
       include 'mpi.cmn'
@@ -114,7 +114,7 @@ c     opens binary input files (filed and part files) and checks for
 c     the filetype
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
 c
       character*(*) file
@@ -148,7 +148,7 @@ c     if the first line contains sdds then it returns the constant
 c     sdds, otherwise it returns the constant original
 c     ----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
 
       character*(*) file
@@ -181,7 +181,7 @@ c     this routine reads in the user input files.
 c     it assumes the standard fortran namelist format.
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'input.cmn'
 c
@@ -273,7 +273,7 @@ c     =============================================================
 c     read the file for external description of the electron beam
 c     -------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'time.cmn'
       include 'io.cmn'
@@ -471,7 +471,7 @@ c     =================================================================
 c     extract information from beamfile
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
 c
       character*(*) line
       character*511 cline
@@ -590,7 +590,7 @@ c     ==============================================
 c     read field from input file
 c     ----------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
       include 'input.cmn'
       include 'field.cmn'
@@ -620,7 +620,7 @@ c     apply dispersion to imported beam file from readpart
 c     subroutine supplied by Atoosa Meseck from Bessy
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
 c
@@ -702,7 +702,7 @@ c     =================================================================
 c     Transfer matrix calculation supplied by A. Meseck. 
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
       include 'input.cmn'
       include 'field.cmn'
@@ -774,7 +774,7 @@ c     =================================================================
 c     load complete set of particle from file
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'io.cmn' 
@@ -853,7 +853,7 @@ c     =================================================================
 c     read slice [tmin,tmax] of particle from distribution file
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'time.cmn'
       include 'io.cmn'
 
@@ -950,7 +950,7 @@ c     open an external file containing the distribution. read the file
 c     geting the parameter range etc.
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'particle.cmn'
       include 'input.cmn'
       include 'time.cmn'
@@ -1114,7 +1114,7 @@ c     =================================================================
 c     extract information from distfile
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'io.cmn'
@@ -1261,7 +1261,7 @@ c     sets default values of program inputs.
 c     default parameter modelled after the pegasus fel      
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'field.cmn'
 c
@@ -1491,7 +1491,7 @@ c     =============================================================
 c     read the file for external description of the radiation beam
 c     -------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'time.cmn'
       include 'io.cmn'
@@ -1658,7 +1658,7 @@ c     =================================================================
 c     extract information from beamfile
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
 c
       character*(*) line
       character*511 cline

--- a/loadbeam.f
+++ b/loadbeam.f
@@ -3,7 +3,7 @@ c     ===================================================================
 c     this routine fills the phase space for one slice of phase space
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'io.cmn'
@@ -108,7 +108,7 @@ c     ==================================================================
 c     shotnoise algortihm following fawley
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'work.cmn'
@@ -159,7 +159,7 @@ c     ==================================================================
 c     shotnoise algorithm following Penman
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
 c
@@ -200,7 +200,7 @@ c     ==================================================================
 c     do quiet loading of transverse phase space
 c     -------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'particle.cmn'
       include 'input.cmn'
 c
@@ -397,7 +397,7 @@ c     =================================================================
 c     load slice from distribution
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
 c
@@ -595,7 +595,7 @@ c     =======================================================
 c     collimation of the transverse tails
 c     ----------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'particle.cmn'
       include 'input.cmn'
 c

--- a/loadrad.f
+++ b/loadrad.f
@@ -4,7 +4,7 @@ c     fills the array crfield with initial field
 c     for start up from noise this should be small
 c     ---------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
       include 'work.cmn'
@@ -75,7 +75,7 @@ c
 c     Note - only the fundamental is loaded. harmonics are set to zero
 c     --------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'sim.cmn'
       include 'field.cmn'
       include 'input.cmn'
@@ -119,12 +119,12 @@ c     fills the array crtime with a seeding field for the first
 c     slice.
 c     ---------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'field.cmn'
       include 'work.cmn'
       include 'io.cmn'
-      include 'timerec.cmn'
+#include "timerec.cmn"
       include 'diagnostic.cmn'
 c
       integer ix,islp,nslp,ierr,irec,i
@@ -197,7 +197,7 @@ c     ========================================
 c     swap current field with then time-record
 c     ----------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'input.cmn'
       include 'field.cmn'

--- a/magfield.f
+++ b/magfield.f
@@ -15,7 +15,7 @@ c                     k3pp - correction in x
 c
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'magnet.cmn'
       include  'mpi.cmn'
@@ -337,7 +337,7 @@ c     calculation of the square of the off-axis wiggler field at step i
 c     the dependency on x and y is given by the wiggler type
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'magnet.cmn'
       include  'input.cmn'
 c
@@ -357,7 +357,7 @@ c     ===================================================================
 c     output of the used magentic field
 c     -------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'magnet.cmn'
       include 'input.cmn'
 c
@@ -485,7 +485,7 @@ c     note: dp,co qx are combined into awerx. output is only dp
 
 c     --------------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'magnet.cmn'
       include 'input.cmn'
 c
@@ -743,7 +743,7 @@ c     checks whether the user supplied file for the description of the
 c     magnetic fields is incomplete
 c     -------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
 c
       character*30   cmagtype(11)
       integer i,j,imz(11),nstepz
@@ -774,7 +774,7 @@ c     =================================================================
 c     extract information from beamfile
 c     -----------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'magnet.cmn'
 c
       character*(*) line

--- a/main.f
+++ b/main.f
@@ -47,7 +47,7 @@ c     main unit
 c     ------------------------------------------------------------------
       program genesis
 c
-      include 'genesis.def' 
+#include "genesis.def"
 c
       include 'mpi.cmn'
 c

--- a/mpi_multi.f
+++ b/mpi_multi.f
@@ -1,6 +1,6 @@
       subroutine mpi_merge
 
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'input.cmn'
       include 'io.cmn'

--- a/mpi_single.f
+++ b/mpi_single.f
@@ -8,7 +8,7 @@ c
 c     ----------------------------------
       subroutine MPI_INIT(i1)
 c   
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
 c    
       integer i1

--- a/output.f
+++ b/output.f
@@ -3,7 +3,7 @@ c     =============================================
 c     calls all output function
 c     ---------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
       include 'diagnostic.cmn'
 c
@@ -24,7 +24,7 @@ c     ==================================================================
 c     initial output of genesis.
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'input.cmn'
       include 'io.cmn'
@@ -321,7 +321,7 @@ c     output of global parameter (t-independend):
 c     z, wiggler field
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'magnet.cmn'
       include  'io.cmn'
@@ -455,7 +455,7 @@ c     output calculation results
 c        - history record
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'diagnostic.cmn'
       include  'field.cmn'
@@ -530,7 +530,7 @@ c     output calculation results
 c        - history record
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'input.cmn'
       include  'field.cmn'
       include  'particle.cmn'
@@ -640,7 +640,7 @@ c     output of global parameter (t-independend):
 c     z, wiggler field
 c     ------------------------------------------------------------------
 c
-      include  'genesis.def'
+#include "genesis.def"
       include  'io.cmn'
       include  'particle.cmn'
       include  'input.cmn'
@@ -683,7 +683,7 @@ c     ==================================================================
 c     let user know % complete at every 10%.
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'magnet.cmn'
       include 'io.cmn'
@@ -707,7 +707,7 @@ c     ==================================================================
 c     dump fieldarray  
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'io.cmn'
       include 'field.cmn'
@@ -746,9 +746,9 @@ c     ====================================================================
 c     dump complete field array for future use
 c     --------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
-      include 'timerec.cmn'
+#include "timerec.cmn"
       include 'io.cmn'
       include 'work.cmn'
       include 'input.cmn'
@@ -868,7 +868,7 @@ c     ==================================
 c     dumps the escaped slippage field ahead of the bunch
 c     ---------------------------------
 
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'io.cmn'
       include 'work.cmn'
@@ -921,7 +921,7 @@ c     open ascii file (sequential access)
 c     ------------------------------------------------------------------ 
 c    
 c
-      include 'genesis.def'
+#include "genesis.def"
 c
       character*(*) file,status
       integer nio
@@ -939,7 +939,7 @@ c     open binary file (direct access) as addition output file
 c     ------------------------------------------------------------------ 
 c    
 c
-      include 'genesis.def'
+#include "genesis.def"
 c
       character*30 root
       character*4  extension
@@ -967,7 +967,7 @@ c     ===========================================
 c     open binary file for field, particle, dump field and dump particle
 c     ------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'io.cmn'
       include 'input.cmn'
@@ -1027,7 +1027,7 @@ c     ===========================================
 c     close binary file for field, particle, dump field and dump particle
 c     ------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'mpi.cmn'
       include 'io.cmn'
       include 'field.cmn'
@@ -1060,7 +1060,7 @@ c     ============================================
 c     initial information for user
 c     --------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
 c 
       write(nlog,100) genver,platf
@@ -1078,7 +1078,7 @@ c     called at end of run.
 c     closes all files, which must stay open during the run
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
       include 'mpi.cmn'
 c
@@ -1116,7 +1116,7 @@ c     ========================================================
 c     print error messages
 c     --------------------------------------------------------
       
-      include 'genesis.def'
+#include "genesis.def"
       include 'io.cmn'
 
       integer ierr

--- a/partsim.f
+++ b/partsim.f
@@ -5,7 +5,7 @@ c     t... are the values of the variables at current position
 c     d... are the value of the differentioan equation
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'work.cmn'
@@ -56,7 +56,7 @@ c     calculates source term for gamma-theta integration
 c     when higher harmonic coupling is considered
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
       include 'magnet.cmn'
@@ -129,7 +129,7 @@ c     ============================================================
 c     routine to calculate the coupling to higher modes
 c     ------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn' 
       include 'input.cmn'
 c

--- a/pushp.f
+++ b/pushp.f
@@ -3,7 +3,7 @@ c     ==================================================================
 c     advance the particles, using runge-kutta (fourth order) method
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'work.cmn'
@@ -132,7 +132,7 @@ c     ========================================================================
 c     checks for lost particles, reorganizing the particle arrays
 c     ------------------------------------------------------------------------ 
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
 c

--- a/rpos.f
+++ b/rpos.f
@@ -4,7 +4,7 @@ c     locates the position of the electron on its actual trajectory
 c     apply orbit correction to account for wiggle motion.
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
       include 'magnet.cmn'
@@ -103,7 +103,7 @@ c     and the particla phase theta.
 c     getpsi is only called by outpart to get a non moving bucket.
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
       include 'particle.cmn'

--- a/scan.f
+++ b/scan.f
@@ -3,7 +3,7 @@ c     ============================================================
 c     initialize beam parameter for scanning
 c     ------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'sim.cmn'
 c
@@ -45,7 +45,7 @@ c     =========================================================================
 c     modify parameter for scanning - several subroutines have to be rerun
 c     -------------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
       include 'particle.cmn'

--- a/source.f
+++ b/source.f
@@ -4,7 +4,7 @@ c     construct the source for the wave equation
 c     = radiation of the electron beam
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'field.cmn'
       include 'input.cmn'
       include 'magnet.cmn'

--- a/stepz.f
+++ b/stepz.f
@@ -3,7 +3,7 @@ c     ==================================================================
 c     advance one step in z
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'magnet.cmn'
       include 'particle.cmn'

--- a/tdepend.f
+++ b/tdepend.f
@@ -3,7 +3,7 @@ c     ===================================================================
 c     set the beam parameter for the case of time-dependence
 c     -------------------------------------------------------------------
 c   
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'particle.cmn'
       include 'time.cmn'
@@ -78,7 +78,7 @@ c     set the beam parameter for the case of time-dependence
 c     -------------------------------------------------------------------
 c   
 
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'field.cmn'
       include 'time.cmn'

--- a/timerec.cmn
+++ b/timerec.cmn
@@ -7,8 +7,8 @@ c
       integer ntmax,nofile
 c
       parameter(
-#if defined(WIN)
-     +          ntmax  = 151*151*500, !must be > than ncar*ncar*nslp(98)
+#if WIN == 1
+     +          ntmax  = 151*501*500, !must be > than ncar*ncar*nslp(98)
 #else
      +          ntmax  = 501*501*500, !must be > than ncar*ncar*nslp(98)
 #endif

--- a/timerec.cmn
+++ b/timerec.cmn
@@ -7,7 +7,11 @@ c
       integer ntmax,nofile
 c
       parameter(
+#if defined(WIN)
+     +          ntmax  = 151*151*500, !must be > than ncar*ncar*nslp(98)
+#else
      +          ntmax  = 501*501*500, !must be > than ncar*ncar*nslp(98)
+#endif
      +          nofile = 0)   !<>0 -> slippage is stored on disk
 c
 c     --------------------------------------------------------------------

--- a/timerec.f
+++ b/timerec.f
@@ -3,8 +3,8 @@ c     ==================================================================
 c     opens a scratch-file for the time record if necessary
 c     ------------------------------------------------------------------
 c  
-      include 'genesis.def'
-      include 'timerec.cmn'
+#include "genesis.def"
+#include "timerec.cmn"
       include 'mpi.cmn'
 c      
       integer n
@@ -29,8 +29,8 @@ c     ==================================================================
 c     copies cpush into crtime array/file
 c     ------------------------------------------------------------------
 
-      include 'genesis.def'
-      include 'timerec.cmn'
+#include "genesis.def"
+#include "timerec.cmn"
       include 'field.cmn'
       include 'mpi.cmn'
 
@@ -65,8 +65,8 @@ c     ==================================================================
 c     copies crtime array/file into cpush
 c     ------------------------------------------------------------------
 
-      include 'genesis.def'
-      include 'timerec.cmn'
+#include "genesis.def"
+#include "timerec.cmn"
       include 'field.cmn'
       include 'mpi.cmn'
 
@@ -101,8 +101,8 @@ c     ====================================================================
 c     close the scratch file if necessary
 c     --------------------------------------------------------------------
 c
-      include 'genesis.def'
-      include 'timerec.cmn'
+#include "genesis.def"
+#include "timerec.cmn"
       include 'mpi.cmn'
 c
       if (mpi_id.gt.0) return   ! only the head node is managing the time-record

--- a/track.f
+++ b/track.f
@@ -5,7 +5,7 @@ c     this subroutine is call before and after runge-kutta integration
 c     of phase and energy
 c     ------------------------------------------------------------------
 c
-      include 'genesis.def'
+#include "genesis.def"
       include 'input.cmn'
       include 'magnet.cmn'
       include 'particle.cmn'


### PR DESCRIPTION
Windows imposes a limitation on the maximum size of static memory allocated.
Genesis2 uses huge memory arrays that are statically allocated and that breaks the build.
This Pull Request adds a new definition into CMakeLists to detect windows builds and apply a preprocessor to `genesis.def` and `timerec.cmn` to reduce sizes of the arrays.