### PR TITLE
FIX: Apply fast_cat patch from lume-genesis.

### DIFF
--- a/input.f
+++ b/input.f
@@ -1377,7 +1377,7 @@ c
       do i=12,14+1*nhmax
          lout(i)=0 
       enddo
-      iotail=0                !<>0 => output include also slippage
+      iotail=1                !<>0 => output include also slippage. Using iotail != 1 produces incomplete output.
       idump=0                 !<>0 => dump complete radiation field.
       nharm=1                 !# or harmonics in the bunching factor
       iallharm=0              !<>0 => all higher harmonics are calculated up to nharm 

--- a/mpi_multi.f
+++ b/mpi_multi.f
@@ -7,7 +7,8 @@
       include 'field.cmn'
 c
       integer i,ih,islice,mpi_tmp,status(MPI_STATUS_SIZE)
-      character*80  command
+      character*255  cmd,opf
+      character*10  nhs
 
       if (iphsty.le.0) return  ! no output at all
 c
@@ -25,79 +26,151 @@ c
 c
 c     mergin main output files
 c
-      do islice=firstout+1,nslice
-       if (mod(islice,ishsty).eq.0) then
-         write(command,10) outputfile(1:strlen(outputfile)),islice,
-     c                     outputfile(1:strlen(outputfile)) 
-         call system(command)
-         write(command,20) outputfile(1:strlen(outputfile)),islice
-         call system(command)
-       endif
-      enddo
+!       do islice=firstout+1,nslice
+!        if (mod(islice,ishsty).eq.0) then
+!          write(cmd,10) outputfile(1:strlen(outputfile)),islice,
+!      c                     outputfile(1:strlen(outputfile)) 
+!          call system(cmd)
+!          write(cmd,20) outputfile(1:strlen(outputfile)),islice
+!          call system(cmd)
+!        endif
+!       enddo
+
+      opf=trim(outputfile)
+
+      cmd='cat '//trim(opf)//'.slice* >> '//trim(opf)
+      print *, trim(cmd)
+      call system(trim(cmd))
 c
 c     merging particle binary output
 c
       if ((ippart.gt.0).and.(ispart.gt.0)) then
-        do islice=firstout+1,nslice
-          write(command,30) outputfile(1:strlen(outputfile)),islice,
-     c                     outputfile(1:strlen(outputfile)) 
-          call system(command)
-          write(command,40) outputfile(1:strlen(outputfile)),islice
-          call system(command)
-        enddo
+!         do islice=firstout+1,nslice
+!           write(cmd,30) outputfile(1:strlen(outputfile)),islice,
+!      c                     outputfile(1:strlen(outputfile)) 
+!           call system(cmd)
+!           write(cmd,40) outputfile(1:strlen(outputfile)),islice
+!           call system(cmd)
+!         enddo
+! rm
+        cmd='mv `ls '//trim(opf)//'.par.slice*|head -1`'
+        cmd=trim(cmd)//' '//trim(opf)//'.par'
+        print *, trim(cmd)
+        call system(trim(cmd))
+! cat
+        cmd='cat '//trim(opf)//'.par.slice* >> '//trim(opf)
+        cmd=trim(cmd)//'.par'
+        print *, trim(cmd)
+        call system(trim(cmd))
       endif
       if (idmppar.ne.0) then
-        do islice=firstout+1,nslice
-          write(command,31) outputfile(1:strlen(outputfile)),islice,
-     c                     outputfile(1:strlen(outputfile)) 
-          call system(command)
-          write(command,41) outputfile(1:strlen(outputfile)),islice
-          call system(command)
-        enddo
+!         do islice=firstout+1,nslice
+!           write(cmd,31) outputfile(1:strlen(outputfile)),islice,
+!      c                     outputfile(1:strlen(outputfile)) 
+!           call system(cmd)
+!           write(cmd,41) outputfile(1:strlen(outputfile)),islice
+!           call system(cmd)
+!         enddo
+! rm
+        cmd='mv `ls '//trim(opf)//'.dpa.slice*|head -1`'
+        cmd=trim(cmd)//' '//trim(opf)//'.dpa'
+        print *, trim(cmd)
+        call system(trim(cmd))
+! cat
+        cmd='cat '//trim(opf)//'.dpa.slice* >> '
+        cmd=trim(cmd)//trim(opf)//'.dpa'
+        print *, trim(cmd)
+        call system(trim(cmd))
       endif
 c 
 c
 c     merging field binary output
 c
       if ((ipradi.gt.0).and.(isradi.gt.0)) then
-        do islice=firstout+1,nslice
-          write(command,50) outputfile(1:strlen(outputfile)),islice,
-     c                     outputfile(1:strlen(outputfile)) 
-          call system(command)
-          write(command,60) outputfile(1:strlen(outputfile)),islice
-          call system(command)
-        enddo
+!         do islice=firstout+1,nslice
+!           write(cmd,50) outputfile(1:strlen(outputfile)),islice,
+!      c                     outputfile(1:strlen(outputfile)) 
+!           call system(cmd)
+!           write(cmd,60) outputfile(1:strlen(outputfile)),islice
+!           call system(cmd)
+!         enddo
+! rm
+        cmd='mv `ls '//trim(opf)//'.fld.slice* | head -1`'
+        cmd=trim(cmd)//' '//trim(opf)//'.fld'
+        print *, trim(cmd)
+        call system(trim(cmd))
+! cat
+        cmd='cat '//trim(opf)//'.fld.slice* >> '
+        cmd=trim(cmd)//trim(opf)//'.fld'
+        print *, trim(cmd)
+        call system(trim(cmd))
         do ih=2,nhloop
-          do islice=firstout+1,nslice
-           write(command,70) outputfile(1:strlen(outputfile)),hloop(ih)
-     c        ,islice,outputfile(1:strlen(outputfile)) ,hloop(ih)
-           call system(command)
-           write(command,80) outputfile(1:strlen(outputfile)),hloop(ih)
-     c                   ,islice
-           call system(command)
-         enddo
+!           do islice=firstout+1,nslice
+!            write(cmd,70) outputfile(1:strlen(outputfile)),hloop(ih)
+!      c        ,islice,outputfile(1:strlen(outputfile)) ,hloop(ih)
+!            call system(cmd)
+!            write(cmd,80) outputfile(1:strlen(outputfile)),hloop(ih)
+!      c                   ,islice
+!            call system(cmd)
+!          enddo
+	  write(nhs,"(I1.1)") hloop(ih)
+  ! rm
+	  cmd='mv `ls '//trim(opf)//'.fld'//trim(nhs)//'.slice* |'
+	  cmd=trim(cmd)//' head -1` '//trim(opf)//'.fld'//trim(nhs)
+	  print *, trim(cmd)
+	  call system(trim(cmd))
+  ! cat
+	  cmd='cat '//trim(opf)//'.fld'//trim(nhs)//'.slice*'
+	  cmd=trim(cmd)//' >> '//trim(opf)//'.fld'//trim(nhs)
+	  print *, trim(cmd)
+	  call system(trim(cmd))
         enddo
       endif
       if (idmpfld.ne.0) then
-        do islice=firstout+1,nslice
-          write(command,51) outputfile(1:strlen(outputfile)),islice,
-     c                     outputfile(1:strlen(outputfile)) 
-          call system(command)
-          write(command,61) outputfile(1:strlen(outputfile)),islice
-          call system(command)
-        enddo
+!         do islice=firstout+1,nslice
+!           write(cmd,51) outputfile(1:strlen(outputfile)),islice,
+!      c                     outputfile(1:strlen(outputfile)) 
+!           call system(cmd)
+!           write(cmd,61) outputfile(1:strlen(outputfile)),islice
+!           call system(cmd)
+!         enddo
+! rm
+        cmd='mv `ls '//trim(opf)//'.dfl.slice* | head -1`'
+        cmd=trim(cmd)//' '//trim(opf)//'.dfl'
+        print *, trim(cmd)
+        call system(trim(cmd))
+! cat
+        cmd='cat '//trim(opf)
+        cmd=trim(cmd)//'.dfl.slice* >> '//trim(opf)//'.dfl'
+        print *, trim(cmd)
+        call system(trim(cmd))
         do ih=2,nhloop
-          do islice=firstout+1,nslice
-           write(command,71) outputfile(1:strlen(outputfile)),hloop(ih)
-     c        ,islice,outputfile(1:strlen(outputfile)) ,hloop(ih)
-           call system(command)
-           write(command,81) outputfile(1:strlen(outputfile)),hloop(ih)
-     c                   ,islice
-           call system(command)
-         enddo
+!           do islice=firstout+1,nslice
+!            write(cmd,71) outputfile(1:strlen(outputfile)),hloop(ih)
+!      c        ,islice,outputfile(1:strlen(outputfile)) ,hloop(ih)
+!            call system(cmd)
+!            write(cmd,81) outputfile(1:strlen(outputfile)),hloop(ih)
+!      c                   ,islice
+!            call system(cmd)
+!          enddo
+	  write(nhs,"(I1.1)") hloop(ih)
+! rm
+          cmd='mv `ls '//trim(opf)//'.dfl'//trim(nhs)//'.slice*'
+          cmd=trim(cmd)//' | head -1` '//trim(opf)//'.dfl'//trim(nhs)
+	  print *, trim(cmd)
+	  call system(trim(cmd))
+! cat
+	  cmd='cat '//trim(opf)//'.dfl'//trim(nhs)
+	  cmd=trim(cmd)//'.slice* >> '//trim(opf)//'.dfl'//trim(nhs)
+	  print *, trim(cmd)
+	  call system(trim(cmd))
         enddo
       endif
-c 
+c     
+!       clean up
+      cmd='rm '//trim(opf)//'*slice*'
+      print *, trim(cmd)
+      call system(trim(cmd))
 
  
       return


### PR DESCRIPTION
Closes #12 and #15 .

The way `fast_cat` patch handles the concatenation of slices and also removal makes so that no errors are generated when we pass in a simple input file with no MPI parameters in it.

Pending @ChristopherMayes validation with a blessed version of Genesis so we can investigate why outputs are different between MPI and non-MPI versions.