### PR TITLE
Longer filenames 30 -> 2000 characters

### DIFF
--- a/genesis.def
+++ b/genesis.def
@@ -8,7 +8,7 @@ c
       integer original,f_sdds,keepdist
 c
       parameter(
-     +          genver = 2.5,                !genesis version
+     +          genver = 2.6,                !genesis version
 #if WIN == 1
      +			platf  ='Win ',              !platform
 #else

--- a/input.cmn
+++ b/input.cmn
@@ -28,9 +28,9 @@ c     output
       integer   iotail,nharm,iallharm,iharmsc,magin,magout,lout
       integer   idmpfld,idmppar,idump,ilog,ffspec	
 c     external files
-      character*30  beamfile,fieldfile,maginfile,magoutfile
-      character*30  outputfile,inputfile,partfile,distfile
-      character*30  filetype,radfile 	   
+      character*2000  beamfile,fieldfile,maginfile,magoutfile
+      character*2000  outputfile,inputfile,partfile,distfile,radfile 
+      character*30  filetype   
 c     time-dependency
       real*8    curlen,shotnoise
       integer   ntail,nslice,iall,itdp,ipseed,ndcut,isntyp

--- a/input.f
+++ b/input.f
@@ -10,7 +10,7 @@ c     ------------------------------------------------------------------
       include 'field.cmn'
 
       integer ierr1,ierr2,i,ih
-      character*34 file
+      character*2000 file
       character*11  file_id
       character*4   file_ext
 c
@@ -247,7 +247,7 @@ c
 c        read(5,110) inputfile                        !get input filename.
       endif
       if (mpi_size.gt.1) then
-        call MPI_BCAST(inputfile,30,MPI_CHARACTER,0,
+        call MPI_BCAST(inputfile,2000,MPI_CHARACTER,0,
      c                MPI_COMM_WORLD,mpi_err)
       endif
 c


### PR DESCRIPTION
Previously filenames were restricted to 30 characters, which didn't allow referencing files with longer paths. This simply makes the maximum filename length to 2000 characters. 

Version bumped to 2.6